### PR TITLE
Faulty transition for robustness test

### DIFF
--- a/server/etcdserver/api/rafthttp/faulty_encoder.go
+++ b/server/etcdserver/api/rafthttp/faulty_encoder.go
@@ -1,0 +1,612 @@
+package rafthttp
+
+import (
+	"container/heap"
+	"fmt"
+	"io"
+	"math/rand"
+	"strconv"
+	"strings"
+	"time"
+
+	"go.etcd.io/etcd/client/pkg/v3/types"
+	"go.etcd.io/raft/v3/raftpb"
+	"go.uber.org/zap"
+)
+
+type FaultType int
+
+const (
+	FaultTypeNone       FaultType = 0
+	FaultTypeDropped              = 0x02
+	FaultTypeDuplicated           = 0x04
+	FaultTypeDelayed              = 0x08
+	FaultTypeReordered            = 0x10
+	FaultTypeBlocked              = 0x12
+)
+
+type FaultyNetworkFaultConfig struct {
+	DropPropability      float64
+	DuplicateProbability float64
+	DelayProbability     float64
+	MinDelayInSecond     float64
+	MaxDelayInSecond     float64
+	BlockInSecond        float64
+}
+
+// FaultyNetworkTransport defines a peer-peer transport between two nodes specified by node ids.
+// zero node id refers to any node.
+// when duplex is true, the transport can be from->to or to->from.
+type FaultyNetworkTransport struct {
+	From   uint64
+	To     uint64
+	Duplex bool
+}
+
+type FaultyNetworkConfig map[FaultyNetworkTransport]FaultyNetworkFaultConfig
+type FaultyNetworkEffectiveConfig map[uint64]FaultyNetworkFaultConfig
+
+type FaultStat struct {
+	Dropped    uint64 `json:"dropped,omitempty"`
+	Duplicated uint64 `json:"duplicated,omitempty"`
+	Delayed    uint64 `json:"delayed,omitempty"`
+	Reordered  uint64 `json:"reordered,omitempty"`
+}
+
+var reportFaultStatisticsInterval time.Duration = time.Second * 10
+
+// config example: 111->222:drop=0.1,delay=0.2:1-3;456:block=2;333<->*:dup:0.2;*:dup=0.05
+// explain:
+// 1. messages sent from node 111 to node 222 will be dropped with 10% chance, be delayed by 1 to 3 seconds with 20% chance, and be bocked by 2 seconds.
+// 2. messages sent from or to 333, will be duplicated with 20% chance.
+// 3. for all transports that are specified above, a message may be duplicated with 5% chance
+func (fnc *FaultyNetworkConfig) String() string {
+	cfgStrs := []string{}
+	for tr, p := range *fnc {
+		pstrs := []string{}
+		if p.DropPropability != 0 {
+			pstrs = append(pstrs, fmt.Sprintf("drop=%v", p.DropPropability))
+		}
+		if p.DuplicateProbability != 0 {
+			pstrs = append(pstrs, fmt.Sprintf("dup=%v", p.DuplicateProbability))
+		}
+		if p.DelayProbability != 0 {
+			pstrs = append(pstrs, fmt.Sprintf("delay=%v:%v-%v", p.DelayProbability, p.MinDelayInSecond, p.MaxDelayInSecond))
+		}
+		if p.BlockInSecond != 0 {
+			pstrs = append(pstrs, fmt.Sprintf("block=%v", p.BlockInSecond))
+		}
+
+		cfgStrs = append(cfgStrs, fmt.Sprintf("%s:%s", fnc.formatTransport(tr), strings.Join(pstrs, ",")))
+	}
+
+	return strings.Join(cfgStrs, ";")
+}
+
+// parse FaultyNetworkConfig from string.
+// refer to FaultyNetworkConfig.String() for configure format.
+func (fnc *FaultyNetworkConfig) Parse(str string) error {
+	cfg := FaultyNetworkConfig{}
+	cfgTokens := strings.Split(str, ";")
+	for _, ct := range cfgTokens {
+		trStr, pstr, found := strings.Cut(ct, ":")
+		if !found {
+			return fmt.Errorf("invalid faulty network config")
+		}
+
+		p := FaultyNetworkFaultConfig{}
+		var err error
+		propTokens := strings.Split(pstr, ",")
+		for _, pt := range propTokens {
+			key, val, found := strings.Cut(pt, "=")
+			if !found {
+				return fmt.Errorf("invalid fault config key value: %s", pt)
+			}
+			switch key {
+			case "drop":
+				if p.DropPropability, err = strconv.ParseFloat(val, 64); err != nil {
+					return fmt.Errorf("invalid drop probability %v for node %v: %w", key, val, err)
+				}
+			case "dup":
+				if p.DuplicateProbability, err = strconv.ParseFloat(val, 64); err != nil {
+					return fmt.Errorf("invalid dup probability %v for node %v: %w", key, val, err)
+				}
+			case "block":
+				if p.BlockInSecond, err = strconv.ParseFloat(val, 64); err != nil {
+					return fmt.Errorf("invalid block duration %v for node %v: %w", key, val, err)
+				}
+			case "delay":
+				pDelayStr, delayRangeStr, found := strings.Cut(val, ":")
+				if !found {
+					return fmt.Errorf("invalid delay configure: %s", val)
+				}
+				if p.DelayProbability, err = strconv.ParseFloat(pDelayStr, 64); err != nil {
+					return fmt.Errorf("invalid delay probability %v for node %v: %w", key, val, err)
+				}
+				minDelay, maxDelay, found := strings.Cut(delayRangeStr, "-")
+				if !found {
+					return fmt.Errorf("invalid delay range: %s", delayRangeStr)
+				}
+				if p.MinDelayInSecond, err = strconv.ParseFloat(minDelay, 64); err != nil {
+					return fmt.Errorf("invalid delay probability %v for node %v: %w", key, val, err)
+				}
+				if p.MaxDelayInSecond, err = strconv.ParseFloat(maxDelay, 64); err != nil {
+					return fmt.Errorf("invalid delay probability %v for node %v: %w", key, val, err)
+				}
+			}
+		}
+
+		tr, err := fnc.parseTransport(trStr)
+		if err != nil {
+			return fmt.Errorf("invalid transport string %s. error: %w", trStr, err)
+		}
+
+		cfg[tr] = p
+	}
+
+	*fnc = cfg
+	return nil
+}
+
+func (fnc *FaultyNetworkConfig) parseNodeId(nstr string) (uint64, error) {
+	if nstr == "*" {
+		return 0, nil
+	}
+
+	if i, err := strconv.ParseUint(nstr, 10, 64); err == nil {
+		// try to parse not from dec format
+		return i, nil
+	}
+
+	if i, err := strconv.ParseUint(nstr, 16, 64); err == nil {
+		// try to parse not from hex format
+		return i, nil
+	}
+
+	return 0, fmt.Errorf("invalid node id %s", nstr)
+}
+
+func (fnc *FaultyNetworkConfig) parseTransport(str string) (FaultyNetworkTransport, error) {
+	if str == "*" {
+		return FaultyNetworkTransport{
+			From: 0,
+			To:   0,
+		}, nil
+	}
+
+	directions := []string{"<->", "->"}
+	for _, direction := range directions {
+		if from, to, found := strings.Cut(str, direction); found {
+			var err error
+			tr := FaultyNetworkTransport{}
+			if tr.From, err = fnc.parseNodeId(from); err != nil {
+				return tr, err
+			}
+			if tr.To, err = fnc.parseNodeId(to); err != nil {
+				return tr, err
+			}
+			if direction == "<->" {
+				tr.Duplex = true
+			} else {
+				tr.Duplex = false
+			}
+
+			return tr, nil
+		}
+	}
+
+	return FaultyNetworkTransport{}, fmt.Errorf("failed to parse transport %s", str)
+}
+
+func (fnc *FaultyNetworkConfig) formatTransport(tr FaultyNetworkTransport) string {
+	if tr.From == 0 && tr.To == 0 {
+		return "*"
+	}
+
+	var from, to, direction string
+	if tr.From == 0 {
+		from = "*"
+	} else {
+		from = strconv.FormatUint(tr.From, 16)
+	}
+	if tr.To == 0 {
+		to = "*"
+	} else {
+		to = strconv.FormatUint(tr.To, 16)
+	}
+	if tr.Duplex {
+		direction = "<->"
+	} else {
+		direction = "->"
+	}
+
+	return fmt.Sprintf("%s%s%s", from, direction, to)
+}
+
+type msgItem struct {
+	sendAt time.Time
+	m      *raftpb.Message
+	index  uint64
+}
+
+// priority queue that sort items by their sendAt time.
+type msgPriorityQueue []*msgItem
+
+func (pq msgPriorityQueue) Len() int { return len(pq) }
+
+func (pq msgPriorityQueue) Less(i, j int) bool {
+	return pq[i].sendAt.Before(pq[j].sendAt)
+}
+
+func (pq msgPriorityQueue) Swap(i, j int) {
+	pq[i], pq[j] = pq[j], pq[i]
+}
+
+func (pq *msgPriorityQueue) Push(x any) {
+	item := x.(*msgItem)
+	*pq = append(*pq, item)
+}
+
+func (pq *msgPriorityQueue) Pop() any {
+	old := *pq
+	n := len(old)
+	item := old[n-1]
+	old[n-1] = nil // avoid memory leak
+	*pq = old[0 : n-1]
+	return item
+}
+
+// sendQueue buffers delayed messages in a priority queue.
+// each message is associated with a sendAt time when the
+// message shall be sent.
+type sendQueue struct {
+	q msgPriorityQueue
+}
+
+func newSendQueue() *sendQueue {
+	return &sendQueue{
+		q: make(msgPriorityQueue, 0),
+	}
+}
+
+func (sq *sendQueue) len() int {
+	return len(sq.q)
+}
+
+func (sq *sendQueue) push(di *msgItem) {
+	heap.Push(&sq.q, di)
+}
+
+func (sq *sendQueue) pop() *msgItem {
+	return heap.Pop(&sq.q).(*msgItem)
+}
+
+func (sq *sendQueue) peek() *msgItem {
+	n := sq.q.Len()
+	if n <= 0 {
+		return nil
+	}
+
+	return sq.q[n-1]
+}
+
+func (sq *sendQueue) popUntil(t time.Time) []*msgItem {
+	result := []*msgItem{}
+
+	for {
+		if top := sq.peek(); top != nil && top.sendAt.Before(t) {
+			result = append(result, sq.pop())
+		} else {
+			break
+		}
+	}
+
+	return result
+}
+
+type pendingStatusRequest struct {
+	c chan<- pendingStatus
+}
+type pendingStatus struct {
+	nMessages int
+}
+
+type faultMessage struct {
+	m        *raftpb.Message
+	fault    FaultType
+	duration time.Duration //<- only used for delayed or blocked message
+}
+
+// faultEncoder is a wrapper of real encoder. It applies specified faults
+// to the received messages and sent via the wrapped encoder.
+type faultyEncoder struct {
+	localId uint64
+	peerId  uint64
+
+	// original encoder
+	encoder encoder
+
+	// priority queue for delayed messages
+	sendQueue *sendQueue
+
+	// message index
+	currentIndex uint64
+	maxSentIndex uint64
+
+	msgc   chan *faultMessage
+	errorc chan error
+	pendc  chan pendingStatusRequest
+	stopc  chan struct{}
+
+	stat   map[string]*FaultStat
+	logger *zap.Logger
+
+	config    *FaultyNetworkFaultConfig
+	configStr string
+}
+
+type wrappedCloser struct {
+	fe     *faultyEncoder
+	closer io.Closer
+}
+
+func (wc *wrappedCloser) Close() error {
+	wc.fe.Close()
+	return wc.closer.Close()
+}
+
+// wrap the given encoder and closer so that specified faults can be applied to the messages
+func wrapEncoderWithFaultyNetwork(encoder encoder, closer io.Closer, localId types.ID, perrId types.ID, lg *zap.Logger) (encoder, io.Closer) {
+	fe := newFaultyEncoder(encoder, localId, perrId, lg)
+	return fe, &wrappedCloser{fe: fe, closer: closer}
+}
+
+func newFaultyEncoder(encoder encoder, localId types.ID, perrId types.ID, lg *zap.Logger) *faultyEncoder {
+	fe := &faultyEncoder{
+		localId:   uint64(localId),
+		peerId:    uint64(perrId),
+		encoder:   encoder,
+		sendQueue: newSendQueue(),
+		msgc:      make(chan *faultMessage),
+		errorc:    make(chan error),
+		pendc:     make(chan pendingStatusRequest),
+		stopc:     make(chan struct{}),
+		stat:      make(map[string]*FaultStat),
+		logger:    lg,
+		config:    nil,
+	}
+
+	go fe.sendLoop()
+
+	return fe
+}
+
+func (fe *faultyEncoder) encode(m *raftpb.Message) error {
+	fe.updateConfigFromGofail()
+
+	if fe.config == nil {
+		return fe.encoder.encode(m)
+	}
+
+	// block message
+	if fe.config.BlockInSecond > 0 {
+		return fe.sendWithFault(m, FaultTypeBlocked)
+	}
+
+	// drop message
+	if rand.Float64() < fe.config.DropPropability {
+		return fe.sendWithFault(m, FaultTypeDropped)
+	}
+
+	// delayed message
+	if rand.Float64() < fe.config.DelayProbability {
+		return fe.sendWithFault(m, FaultTypeDelayed)
+	}
+
+	// duplicated message. Proposal shall be ignored as it is equivalent to an untracking put request.
+	if rand.Float64() < fe.config.DuplicateProbability && m.Type != raftpb.MsgProp {
+		if rand.Float64() < fe.config.DelayProbability {
+			fe.sendWithFault(m, FaultTypeDelayed|FaultTypeDuplicated)
+		} else {
+			fe.sendWithFault(m, FaultTypeNone|FaultTypeDuplicated)
+		}
+	}
+
+	// send message without fault
+	return fe.sendWithFault(m, FaultTypeNone)
+}
+
+func (fe *faultyEncoder) Close() error {
+	close(fe.stopc)
+	return nil
+}
+
+// faultyEncoder gets realtime fault configuration from gofail failpoints.
+func (fe *faultyEncoder) updateConfigFromGofail() {
+	// gofail: var faultyNetworkCfg string
+	// fe.setConfig(faultyNetworkCfg)
+	// return
+}
+
+func (fe *faultyEncoder) sendWithFault(m *raftpb.Message, faultType FaultType) error {
+	var delay time.Duration
+	switch faultType {
+	case FaultTypeDelayed:
+		delay = time.Duration(float64(time.Second) * (rand.Float64()*(fe.config.MaxDelayInSecond-fe.config.MinDelayInSecond) + fe.config.MinDelayInSecond))
+	case FaultTypeBlocked:
+		delay = time.Duration(float64(time.Second) * fe.config.BlockInSecond)
+	}
+
+	fe.msgc <- &faultMessage{
+		m:        m,
+		fault:    faultType,
+		duration: delay,
+	}
+
+	err := <-fe.errorc
+	return err
+}
+
+func (fe *faultyEncoder) getPendingStatus() pendingStatus {
+	c := make(chan pendingStatus)
+	fe.pendc <- pendingStatusRequest{c: c}
+	r := <-c
+
+	return r
+}
+
+// get effective fault configuration that can be applied to this encoder.
+// using maximum probability/duration that is applicable
+// TODO: calculate effective config so that fault configuration for more specifically matching transport can be applied.
+func (fe *faultyEncoder) getEffectiveConfig(cfg FaultyNetworkConfig) *FaultyNetworkFaultConfig {
+	fc := &FaultyNetworkFaultConfig{}
+	for tr, p := range cfg {
+		if ((fe.localId == tr.From || tr.From == 0) || ((fe.localId == tr.To || tr.To == 0) && tr.Duplex)) &&
+			((fe.peerId == tr.To || tr.To == 0) || ((fe.peerId == tr.From || tr.From == 0) && tr.Duplex)) {
+			fc.BlockInSecond = max(fc.BlockInSecond, p.BlockInSecond)
+			fc.DuplicateProbability = max(fc.DuplicateProbability, p.DuplicateProbability)
+			fc.DropPropability = max(fc.DropPropability, p.DropPropability)
+			if p.DelayProbability > fc.DelayProbability {
+				fc.DelayProbability = p.DelayProbability
+				fc.MinDelayInSecond = p.MinDelayInSecond
+				fc.MaxDelayInSecond = p.MaxDelayInSecond
+			}
+		}
+	}
+
+	return fc
+}
+
+func (fe *faultyEncoder) setConfig(cfgStr string) {
+	cfg := FaultyNetworkConfig{}
+	if cfgStr != fe.configStr {
+		if err := cfg.Parse(cfgStr); err != nil {
+			fe.logger.Error("Failed to parse faulty network config", zap.String("config", cfgStr), zap.Error(err))
+			cfg = nil
+		}
+		if cfg != nil {
+			fe.configStr = cfgStr
+			fe.config = fe.getEffectiveConfig(cfg)
+		}
+
+	}
+}
+
+func (fe *faultyEncoder) recordFault(msgType raftpb.MessageType, faultType FaultType) {
+	if faultType == FaultTypeNone {
+		return
+	}
+
+	typeStr := msgType.String()
+	if _, ok := fe.stat[typeStr]; !ok {
+		fe.stat[typeStr] = &FaultStat{}
+	}
+	switch faultType {
+	case FaultTypeDropped:
+		fe.stat[typeStr].Dropped++
+	case FaultTypeDuplicated:
+		fe.stat[typeStr].Duplicated++
+	case FaultTypeDelayed:
+		fe.stat[typeStr].Delayed++
+	case FaultTypeReordered:
+		fe.stat[typeStr].Reordered++
+	}
+}
+
+func (fe *faultyEncoder) reportFaultStat() {
+	if len(fe.stat) > 0 {
+		fe.logger.Info("Faulty encoder statistics", zap.Uint64("id", fe.peerId), zap.Any("stat", fe.stat))
+	}
+}
+
+func (fe *faultyEncoder) send(m *raftpb.Message, index uint64) error {
+	if m == nil {
+		return nil
+	}
+
+	if index > fe.maxSentIndex {
+		fe.maxSentIndex = index
+	}
+	return fe.encoder.encode(m)
+}
+
+func (fe *faultyEncoder) sendLoop() {
+	timer := time.NewTimer(time.Minute)
+	statTicker := time.NewTicker(reportFaultStatisticsInterval)
+	var notifyc <-chan time.Time
+	var lastIndex uint64
+	for {
+
+		first := fe.sendQueue.peek()
+		if first != nil {
+			if lastIndex != first.index {
+				lastIndex = first.index
+				// reset timer
+				timer.Stop()
+				select {
+				case <-timer.C:
+				default:
+				}
+				duration := time.Until(first.sendAt)
+				timer.Reset(duration)
+				notifyc = timer.C
+			}
+		} else {
+			notifyc = nil
+		}
+
+		select {
+		case fm := <-fe.msgc:
+			isDup := false
+			fault := fm.fault
+			if fault&FaultTypeDuplicated == FaultTypeDuplicated {
+				isDup = true
+				fault = fault & ^FaultTypeDuplicated
+			}
+			var err error
+			switch fault {
+			case FaultTypeNone:
+				err = fe.send(fm.m, fe.currentIndex)
+			case FaultTypeBlocked:
+				time.Sleep(fm.duration)
+				err = fe.send(fm.m, fe.currentIndex)
+			case FaultTypeDropped:
+				err = fe.send(nil, fe.currentIndex)
+			case FaultTypeDelayed:
+				fe.sendQueue.push(&msgItem{
+					sendAt: time.Now().Add(fm.duration),
+					m:      fm.m,
+					index:  fe.currentIndex,
+				})
+			default:
+				fe.logger.Panic("unknown fault", zap.Any("fault", fault))
+			}
+
+			fe.currentIndex++
+
+			fe.recordFault(fm.m.Type, fault)
+			if isDup {
+				fe.recordFault(fm.m.Type, FaultTypeDuplicated)
+			}
+
+			fe.errorc <- err
+
+		case <-notifyc:
+			items := fe.sendQueue.popUntil(time.Now())
+			for _, di := range items {
+				fe.send(di.m, di.index)
+				if di.index < fe.maxSentIndex {
+					fe.recordFault(di.m.Type, FaultTypeReordered)
+				}
+			}
+		case <-statTicker.C:
+			fe.reportFaultStat()
+		case pr := <-fe.pendc:
+			pr.c <- pendingStatus{nMessages: fe.sendQueue.len()}
+		case <-fe.stopc:
+			timer.Stop()
+			statTicker.Stop()
+			return
+		}
+	}
+}

--- a/server/etcdserver/api/rafthttp/faulty_encoder_test.go
+++ b/server/etcdserver/api/rafthttp/faulty_encoder_test.go
@@ -5,9 +5,10 @@ import (
 	"testing"
 	"time"
 
+	"go.uber.org/zap"
+
 	"go.etcd.io/etcd/client/pkg/v3/types"
 	"go.etcd.io/raft/v3/raftpb"
-	"go.uber.org/zap"
 )
 
 type testEncoder struct {
@@ -192,7 +193,7 @@ func TestFaultyEncoderWithBlockedNetwork(t *testing.T) {
 func TestFaultyEncoderWithLossyNetwork(t *testing.T) {
 	tr := FaultyNetworkTransport{
 		From: 0,
-		To:   1,
+		To:   2,
 	}
 	cfg := FaultyNetworkConfig{
 		tr: FaultyNetworkFaultConfig{
@@ -200,7 +201,7 @@ func TestFaultyEncoderWithLossyNetwork(t *testing.T) {
 		},
 	}
 
-	result := runWithConfig(t, cfg, 20, 0, 1) // 99% confidence level
+	result := runWithConfig(t, cfg, 20, 0, 2) // 99% confidence level
 	if !result.hasDropped() {
 		t.Error("some messages shall be dropped")
 	}

--- a/server/etcdserver/api/rafthttp/faulty_encoder_test.go
+++ b/server/etcdserver/api/rafthttp/faulty_encoder_test.go
@@ -1,0 +1,328 @@
+package rafthttp
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"go.etcd.io/etcd/client/pkg/v3/types"
+	"go.etcd.io/raft/v3/raftpb"
+	"go.uber.org/zap"
+)
+
+type testEncoder struct {
+	received     []*raftpb.Message
+	receivedTime []time.Time
+}
+
+func newTestEncoder() *testEncoder {
+	return &testEncoder{
+		received:     make([]*raftpb.Message, 0),
+		receivedTime: make([]time.Time, 0),
+	}
+}
+
+func (te *testEncoder) encode(m *raftpb.Message) error {
+	te.received = append(te.received, m)
+	te.receivedTime = append(te.receivedTime, time.Now())
+	return nil
+}
+
+type testEncodeResult struct {
+	received     []*raftpb.Message
+	receivedTime []time.Time
+	sent         []*raftpb.Message
+	sentTime     []time.Time
+}
+
+func (ter *testEncodeResult) hasReordered() bool {
+	receivedOrders := map[*raftpb.Message]int{}
+	for i, m := range ter.received {
+		receivedOrders[m] = i
+	}
+
+	lastReceiveIndex := -1
+	for _, m := range ter.sent {
+		if i, ok := receivedOrders[m]; ok {
+			if i < lastReceiveIndex {
+				return true
+			}
+			lastReceiveIndex = i
+		}
+	}
+
+	return false
+}
+
+func (ter *testEncodeResult) hasDropped() bool {
+	receivedOrders := map[*raftpb.Message]int{}
+	for i, m := range ter.received {
+		receivedOrders[m] = i
+	}
+
+	for _, m := range ter.sent {
+		if _, ok := receivedOrders[m]; !ok {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (ter *testEncodeResult) hasDuplicated() bool {
+	receivedOrders := map[*raftpb.Message]int{}
+	for i, m := range ter.received {
+		if _, ok := receivedOrders[m]; !ok {
+			receivedOrders[m] = i
+		} else {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (ter *testEncodeResult) hasConsistentCountAndOrder() bool {
+	if len(ter.sent) != len(ter.received) {
+		return false
+	}
+
+	for i, m := range ter.sent {
+		if ter.received[i] != m {
+			return false
+		}
+	}
+
+	return true
+}
+
+func (ter *testEncodeResult) hasBlocked(threshold time.Duration) bool {
+	if ter.receivedTime[0].Sub(ter.sentTime[0]) < threshold {
+		return true
+	}
+
+	prevReceivedTime := ter.receivedTime[0]
+	for i := range ter.received {
+		if ter.receivedTime[i].Sub(ter.sentTime[i]) > threshold && ter.receivedTime[i].Sub(prevReceivedTime) < threshold {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (ter *testEncodeResult) hasDelayed(threshold time.Duration) bool {
+	sentTime := map[*raftpb.Message]time.Time{}
+	for i, m := range ter.sent {
+		sentTime[m] = ter.sentTime[i]
+	}
+
+	for i, m := range ter.received {
+		if ter.receivedTime[i].Sub(sentTime[m]) > threshold {
+			return true
+		}
+	}
+
+	return false
+}
+
+func runWithConfig(t *testing.T, cfg FaultyNetworkConfig, nSend int, sendInterval time.Duration, target uint64) *testEncodeResult {
+	sendMessages := []*raftpb.Message{}
+	for i := 0; i < nSend; i++ {
+		sendMessages = append(sendMessages, &raftpb.Message{To: target})
+	}
+
+	enc := newTestEncoder()
+	fe := newFaultyEncoder(enc, types.ID(0), types.ID(target), zap.NewNop())
+	fe.setConfig(cfg.String())
+
+	result := &testEncodeResult{}
+	for _, m := range sendMessages {
+		result.sent = append(result.sent, m)
+		result.sentTime = append(result.sentTime, time.Now())
+		fe.encode(m)
+		time.Sleep(sendInterval)
+	}
+
+	// wait till send queue is empty (at most 30 seconds)
+	timer := time.NewTimer(30 * time.Second)
+	defer timer.Stop()
+	for {
+		select {
+		case <-timer.C:
+			t.Fatal("timeout in running faulty network tests")
+			return nil
+		default:
+			time.Sleep(time.Millisecond * 100)
+		}
+		pending := fe.getPendingStatus()
+		if pending.nMessages == 0 {
+			break
+		}
+	}
+
+	result.received = enc.received
+	result.receivedTime = enc.receivedTime
+
+	fe.Close()
+
+	return result
+}
+
+func TestFaultyEncoderWithBlockedNetwork(t *testing.T) {
+	tr := FaultyNetworkTransport{
+		From: 0,
+		To:   1,
+	}
+	cfg := FaultyNetworkConfig{
+		tr: FaultyNetworkFaultConfig{
+			BlockInSecond: 0.2,
+		},
+	}
+
+	result := runWithConfig(t, cfg, 3, 0, 1)
+	if !result.hasConsistentCountAndOrder() {
+		t.Error("inconsistent count or order")
+	}
+	if !result.hasBlocked(time.Millisecond * 100) {
+		t.Error("messages shall be blocked")
+	}
+}
+
+func TestFaultyEncoderWithLossyNetwork(t *testing.T) {
+	tr := FaultyNetworkTransport{
+		From: 0,
+		To:   1,
+	}
+	cfg := FaultyNetworkConfig{
+		tr: FaultyNetworkFaultConfig{
+			DropPropability: 0.2,
+		},
+	}
+
+	result := runWithConfig(t, cfg, 20, 0, 1) // 99% confidence level
+	if !result.hasDropped() {
+		t.Error("some messages shall be dropped")
+	}
+}
+
+func TestFaultyEncoderWithLaggyNetwork(t *testing.T) {
+	tr := FaultyNetworkTransport{
+		From: 0,
+		To:   1,
+	}
+	cfg := FaultyNetworkConfig{
+		tr: FaultyNetworkFaultConfig{
+			DelayProbability: 0.5,
+			MinDelayInSecond: 0.5,
+			MaxDelayInSecond: 1,
+		},
+	}
+
+	result := runWithConfig(t, cfg, 20, time.Millisecond*100, 1) // 99% confidence level
+	if !result.hasDelayed(time.Millisecond * 40) {
+		t.Error("some messages shall be delayed")
+	}
+}
+
+func TestFaultyEncoderWithDuplicatedMessages(t *testing.T) {
+	tr := FaultyNetworkTransport{
+		From: 0,
+		To:   1,
+	}
+	cfg := FaultyNetworkConfig{
+		tr: FaultyNetworkFaultConfig{
+			DuplicateProbability: 0.2,
+		},
+	}
+
+	result := runWithConfig(t, cfg, 20, 0, 1) // 99% confidence level
+	if !result.hasDuplicated() {
+		t.Error("some messages shall be duplicated")
+	}
+}
+
+func TestFaultyNetworkWithReorderedMessages(t *testing.T) {
+	tr := FaultyNetworkTransport{
+		From: 0,
+		To:   1,
+	}
+	cfg := FaultyNetworkConfig{
+		tr: FaultyNetworkFaultConfig{
+			DelayProbability: 0.2,
+			MinDelayInSecond: 1,
+			MaxDelayInSecond: 1,
+		},
+	}
+
+	result := runWithConfig(t, cfg, 20, 0, 1) // 99% confidence level
+	if !result.hasReordered() {
+		t.Error("some messages shall be delayed")
+	}
+}
+
+func TestFaultyNetworkWithMismatchedConfig(t *testing.T) {
+	// faulty network is applied for messages sent to node 2
+	tr := FaultyNetworkTransport{
+		From: 0,
+		To:   2,
+	}
+	cfg := FaultyNetworkConfig{
+		tr: FaultyNetworkFaultConfig{
+			DropPropability: 1,
+		},
+	}
+
+	result := runWithConfig(t, cfg, 10, 0, 1)
+	if !result.hasConsistentCountAndOrder() {
+		t.Error("received messages are not aligned with sent ones")
+	}
+}
+
+func TestFaultyNetworkConfigure(t *testing.T) {
+	tr1 := FaultyNetworkTransport{
+		From: 1,
+		To:   2,
+	}
+	tr2 := FaultyNetworkTransport{
+		From:   3,
+		To:     2,
+		Duplex: true,
+	}
+	tr3 := FaultyNetworkTransport{
+		From: 1,
+		To:   0,
+	}
+	tr4 := FaultyNetworkTransport{
+		From: 0,
+		To:   0,
+	}
+	cfg := FaultyNetworkConfig{
+		tr1: FaultyNetworkFaultConfig{
+			DropPropability:      0.1,
+			DuplicateProbability: 0.2,
+		},
+		tr2: FaultyNetworkFaultConfig{
+			BlockInSecond:    1,
+			DelayProbability: 0.5,
+			MinDelayInSecond: 2,
+			MaxDelayInSecond: 3,
+		},
+		tr3: FaultyNetworkFaultConfig{
+			DropPropability: 0.5,
+		},
+		tr4: FaultyNetworkFaultConfig{
+			DropPropability: 0.1,
+		},
+	}
+
+	cfgStr := cfg.String()
+	newCfg := FaultyNetworkConfig{}
+	if err := newCfg.Parse(cfgStr); err != nil {
+		t.Errorf("failed to parse config. error: %s", err)
+	}
+
+	if !reflect.DeepEqual(cfg, newCfg) {
+		t.Error("configure mismatch")
+	}
+}

--- a/server/etcdserver/api/rafthttp/faulty_encoder_test.go
+++ b/server/etcdserver/api/rafthttp/faulty_encoder_test.go
@@ -1,3 +1,17 @@
+// Copyright 2015 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package rafthttp
 
 import (

--- a/server/etcdserver/api/rafthttp/stream.go
+++ b/server/etcdserver/api/rafthttp/stream.go
@@ -260,6 +260,9 @@ func (cw *streamWriter) run() {
 			cw.working = true
 			cw.mu.Unlock()
 
+			// gofail: var faultyNetwork struct{}
+			// enc, cw.closer = wrapEncoderWithFaultyNetwork(enc, cw.closer, cw.localID, cw.peerID, cw.lg)
+
 			if closed {
 				if cw.lg != nil {
 					cw.lg.Warn(
@@ -488,7 +491,6 @@ func (cr *streamReader) decodeLoop(rc io.ReadCloser, t streamType) error {
 	}
 	cr.mu.Unlock()
 
-	// gofail: labelRaftDropHeartbeat:
 	for {
 		m, err := dec.decode()
 		if err != nil {
@@ -497,9 +499,6 @@ func (cr *streamReader) decodeLoop(rc io.ReadCloser, t streamType) error {
 			cr.mu.Unlock()
 			return err
 		}
-
-		// gofail-go: var raftDropHeartbeat struct{}
-		// continue labelRaftDropHeartbeat
 		receivedBytes.WithLabelValues(types.ID(m.From).String()).Add(float64(m.Size()))
 
 		cr.mu.Lock()

--- a/tests/framework/e2e/cluster.go
+++ b/tests/framework/e2e/cluster.go
@@ -137,11 +137,12 @@ type EtcdProcessClusterConfig struct {
 
 	// Test config
 
-	KeepDataDir   bool
-	Logger        *zap.Logger
-	GoFailEnabled bool
-	LazyFSEnabled bool
-	PeerProxy     bool
+	KeepDataDir             bool
+	Logger                  *zap.Logger
+	GoFailEnabled           bool
+	LazyFSEnabled           bool
+	PeerProxy               bool
+	FaultyTransitionEnabled bool
 
 	// Process config
 
@@ -364,6 +365,10 @@ func WithEnvVars(ev map[string]string) EPClusterOption {
 
 func WithPeerProxy(enabled bool) EPClusterOption {
 	return func(c *EtcdProcessClusterConfig) { c.PeerProxy = enabled }
+}
+
+func WithFaultyTransition(enabled bool) EPClusterOption {
+	return func(c *EtcdProcessClusterConfig) { c.FaultyTransitionEnabled = enabled }
 }
 
 // NewEtcdProcessCluster launches a new cluster from etcd processes, returning
@@ -609,23 +614,24 @@ func (cfg *EtcdProcessClusterConfig) EtcdServerProcessConfig(tb testing.TB, i in
 	}
 
 	return &EtcdServerProcessConfig{
-		lg:            cfg.Logger,
-		ExecPath:      execPath,
-		Args:          args,
-		EnvVars:       envVars,
-		TlsArgs:       cfg.TlsArgs(),
-		Client:        cfg.Client,
-		DataDirPath:   dataDirPath,
-		KeepDataDir:   cfg.KeepDataDir,
-		Name:          name,
-		PeerURL:       peerAdvertiseUrl,
-		ClientURL:     curl,
-		ClientHTTPURL: clientHttpUrl,
-		MetricsURL:    murl,
-		InitialToken:  cfg.ServerConfig.InitialClusterToken,
-		GoFailPort:    gofailPort,
-		Proxy:         proxyCfg,
-		LazyFSEnabled: cfg.LazyFSEnabled,
+		lg:                      cfg.Logger,
+		ExecPath:                execPath,
+		Args:                    args,
+		EnvVars:                 envVars,
+		TlsArgs:                 cfg.TlsArgs(),
+		Client:                  cfg.Client,
+		DataDirPath:             dataDirPath,
+		KeepDataDir:             cfg.KeepDataDir,
+		Name:                    name,
+		PeerURL:                 peerAdvertiseUrl,
+		ClientURL:               curl,
+		ClientHTTPURL:           clientHttpUrl,
+		MetricsURL:              murl,
+		InitialToken:            cfg.ServerConfig.InitialClusterToken,
+		GoFailPort:              gofailPort,
+		Proxy:                   proxyCfg,
+		LazyFSEnabled:           cfg.LazyFSEnabled,
+		FaultyTransitionEnabled: cfg.FaultyTransitionEnabled,
 	}
 }
 

--- a/tests/framework/e2e/etcd_process.go
+++ b/tests/framework/e2e/etcd_process.go
@@ -99,8 +99,9 @@ type EtcdServerProcessConfig struct {
 	InitialCluster string
 	GoFailPort     int
 
-	LazyFSEnabled bool
-	Proxy         *proxy.ServerConfig
+	LazyFSEnabled           bool
+	Proxy                   *proxy.ServerConfig
+	FaultyTransitionEnabled bool
 }
 
 func NewEtcdServerProcess(t testing.TB, cfg *EtcdServerProcessConfig) (*EtcdServerProcess, error) {
@@ -162,6 +163,9 @@ func (ep *EtcdServerProcess) Start(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
+	}
+	if ep.cfg.FaultyTransitionEnabled {
+		ep.Failpoints().SetupEnv("faultyNetwork", "return")
 	}
 
 	ep.cfg.lg.Info("starting server...", zap.String("name", ep.cfg.Name))

--- a/tests/robustness/failpoint/failpoint.go
+++ b/tests/robustness/failpoint/failpoint.go
@@ -50,6 +50,7 @@ var (
 		DropPeerNetwork,
 		RaftBeforeSaveSleep,
 		RaftAfterSaveSleep,
+		BlockedTransition, RedundantTransition, LossyTransition, LaggyTransition,
 	}
 )
 

--- a/tests/robustness/failpoint/message_transition.go
+++ b/tests/robustness/failpoint/message_transition.go
@@ -15,7 +15,7 @@ import (
 var (
 	BlockedTransition   Failpoint = makeMessageTransitionFailpoint("traffic-jam", withTrafficJam("", "", true, time.Millisecond*100))
 	LossyTransition     Failpoint = makeMessageTransitionFailpoint("lossy", withLossyTransition("", "", true, 0.2))
-	RedundantTransition Failpoint = makeMessageTransitionFailpoint("redundant", withRedundantTransition("", "", true, 0.2))
+	RedundantTransition Failpoint = makeMessageTransitionFailpoint("redundant", withRedundantTransition("", "", true, 0.2), withLaggyTransition("", "", true, 0.2, time.Millisecond*100, time.Millisecond*500))
 	// laggy transition may also introduce message reordering
 	LaggyTransition Failpoint = makeMessageTransitionFailpoint("laggy", withLaggyTransition("", "", true, 0.2, time.Millisecond*100, time.Millisecond*500))
 )

--- a/tests/robustness/failpoint/message_transition.go
+++ b/tests/robustness/failpoint/message_transition.go
@@ -1,0 +1,185 @@
+package failpoint
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"testing"
+	"time"
+
+	"go.etcd.io/etcd/server/v3/etcdserver/api/rafthttp"
+	"go.etcd.io/etcd/tests/v3/framework/e2e"
+	"go.uber.org/zap"
+)
+
+var (
+	BlockedTransition   Failpoint = makeMessageTransitionFailpoint("traffic-jam", withTrafficJam("", "", true, time.Millisecond*100))
+	LossyTransition     Failpoint = makeMessageTransitionFailpoint("lossy", withLossyTransition("", "", true, 0.2))
+	RedundantTransition Failpoint = makeMessageTransitionFailpoint("redundant", withRedundantTransition("", "", true, 0.2))
+	// laggy transition may also introduce message reordering
+	LaggyTransition Failpoint = makeMessageTransitionFailpoint("laggy", withLaggyTransition("", "", true, 0.2, time.Millisecond*100, time.Millisecond*500))
+)
+
+// define transport between named nodes.
+// node name can be
+// 1. * - any node
+// 2. <empty> - random node
+// 3. <node name> - specific node
+type messageTransitionTransport struct {
+	from   string
+	to     string
+	duplex bool
+}
+type messageTransitionFailpointConfig map[messageTransitionTransport]*rafthttp.FaultyNetworkFaultConfig
+
+type messageTransitionFailpoint struct {
+	// name of the node to inject the failpoint. If it is empty, the failpoint is applied to all nodes.
+	name string
+	cfg  messageTransitionFailpointConfig
+}
+
+func (f messageTransitionFailpoint) Inject(ctx context.Context, t *testing.T, lg *zap.Logger, clus *e2e.EtcdProcessCluster) error {
+	cfg := rafthttp.FaultyNetworkConfig{}
+	for k, v := range f.cfg {
+		var from, to uint64
+		var err error
+		for {
+			from, err = getMemberId(clus, k.from)
+			if err != nil {
+				return err
+			}
+			to, err = getMemberId(clus, k.to)
+			if err != nil {
+				return err
+			}
+
+			// from and two have different id
+			if from != to ||
+				// any to any transport
+				from == 0 ||
+				// both node names are specifically set
+				(len(k.from) != 0 && len(k.to) != 0) ||
+				// this is a single node cluster
+				len(clus.Procs) == 1 {
+				break
+			}
+		}
+
+		tr := rafthttp.FaultyNetworkTransport{
+			From:   from,
+			To:     to,
+			Duplex: k.duplex,
+		}
+		cfg[tr] = *v
+	}
+	for _, m := range clus.Procs {
+		if err := m.Failpoints().SetupHTTP(ctx, "faultyNetworkCfg", fmt.Sprintf(`return("%s")`, cfg.String())); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (f messageTransitionFailpoint) Name() string {
+	return f.name
+}
+
+func (f messageTransitionFailpoint) Available(cfg e2e.EtcdProcessClusterConfig, member e2e.EtcdProcess) bool {
+	if cfg.ClusterSize == 1 {
+		return false
+	}
+
+	memberFailpoints := member.Failpoints()
+	if memberFailpoints == nil {
+		return false
+	}
+	return memberFailpoints.Available("faultyNetworkCfg")
+}
+
+func getMemberId(clus *e2e.EtcdProcessCluster, name string) (uint64, error) {
+	if name == "*" {
+		return 0, nil // 0 refers to any member
+	}
+
+	resp, err := clus.Etcdctl().MemberList(context.TODO(), true)
+	if err != nil {
+		return 0, err
+	}
+	if len(name) == 0 {
+		// pick random member
+		return resp.Members[rand.Intn(len(resp.Members))].ID, nil
+	}
+	for _, m := range resp.Members {
+		if m.GetName() == name {
+			return m.ID, nil
+		}
+	}
+
+	return 0, fmt.Errorf("no member found with name %s", name)
+}
+
+type messageTransitionFailpointOption func(cfg *messageTransitionFailpointConfig)
+
+func makeMessageTransitionFailpoint(name string, opts ...messageTransitionFailpointOption) Failpoint {
+	cfg := &messageTransitionFailpointConfig{}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+
+	return &messageTransitionFailpoint{
+		name: name,
+		cfg:  *cfg,
+	}
+}
+
+func withFaultConfig(from string, to string, duplex bool, fc rafthttp.FaultyNetworkFaultConfig) messageTransitionFailpointOption {
+	return func(cfg *messageTransitionFailpointConfig) {
+		validTr := []messageTransitionTransport{
+			messageTransitionTransport{from: from, to: to, duplex: duplex},
+			messageTransitionTransport{from: to, to: from, duplex: true},
+		}
+		found := false
+		for _, tr := range validTr {
+			if f, ok := (*cfg)[tr]; ok {
+				f.BlockInSecond = max(f.BlockInSecond, fc.BlockInSecond)
+				f.DropPropability = max(f.DropPropability, fc.DropPropability)
+				f.DuplicateProbability = max(f.DuplicateProbability, fc.DuplicateProbability)
+				if f.DelayProbability < fc.DelayProbability {
+					f.DelayProbability = fc.DelayProbability
+					f.MinDelayInSecond = fc.MinDelayInSecond
+					f.MaxDelayInSecond = fc.MaxDelayInSecond
+				}
+				found = true
+			}
+		}
+
+		if !found {
+			tr := messageTransitionTransport{
+				from:   from,
+				to:     to,
+				duplex: duplex,
+			}
+			(*cfg)[tr] = &fc
+		}
+	}
+}
+
+func withTrafficJam(from string, to string, duplex bool, duration time.Duration) messageTransitionFailpointOption {
+	return withFaultConfig(from, to, duplex, rafthttp.FaultyNetworkFaultConfig{BlockInSecond: duration.Seconds()})
+}
+
+func withLossyTransition(from string, to string, duplex bool, p float64) messageTransitionFailpointOption {
+	return withFaultConfig(from, to, duplex, rafthttp.FaultyNetworkFaultConfig{DropPropability: p})
+}
+
+func withRedundantTransition(from string, to string, duplex bool, p float64) messageTransitionFailpointOption {
+	return withFaultConfig(from, to, duplex, rafthttp.FaultyNetworkFaultConfig{DuplicateProbability: p})
+}
+
+func withLaggyTransition(from string, to string, duplex bool, p float64, minDelay time.Duration, maxDelay time.Duration) messageTransitionFailpointOption {
+	return withFaultConfig(from, to, duplex, rafthttp.FaultyNetworkFaultConfig{
+		DelayProbability: p,
+		MinDelayInSecond: maxDelay.Seconds(),
+		MaxDelayInSecond: maxDelay.Seconds(),
+	})
+}

--- a/tests/robustness/failpoint/message_transition.go
+++ b/tests/robustness/failpoint/message_transition.go
@@ -1,3 +1,17 @@
+// Copyright 2015 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package failpoint
 
 import (

--- a/tests/robustness/makefile.mk
+++ b/tests/robustness/makefile.mk
@@ -36,7 +36,7 @@ GOFAIL_VERSION = $(shell cd tools/mod && go list -m -f {{.Version}} go.etcd.io/g
 
 .PHONY: gofail-enable
 gofail-enable: install-gofail
-	gofail enable server/etcdserver/ server/storage/backend/ server/storage/mvcc/ server/storage/wal/
+	gofail enable server/etcdserver/ server/storage/backend/ server/storage/mvcc/ server/storage/wal/ server/etcdserver/api/rafthttp/
 	cd ./server && go get go.etcd.io/gofail@${GOFAIL_VERSION}
 	cd ./etcdutl && go get go.etcd.io/gofail@${GOFAIL_VERSION}
 	cd ./etcdctl && go get go.etcd.io/gofail@${GOFAIL_VERSION}
@@ -44,7 +44,7 @@ gofail-enable: install-gofail
 
 .PHONY: gofail-disable
 gofail-disable: install-gofail
-	gofail disable server/etcdserver/ server/storage/backend/ server/storage/mvcc/ server/storage/wal/
+	gofail disable server/etcdserver/ server/storage/backend/ server/storage/mvcc/ server/storage/wal/ server/etcdserver/api/rafthttp/
 	cd ./server && go mod tidy
 	cd ./etcdutl && go mod tidy
 	cd ./etcdctl && go mod tidy

--- a/tests/robustness/scenarios.go
+++ b/tests/robustness/scenarios.go
@@ -93,6 +93,7 @@ func scenarios(t *testing.T) []testScenario {
 		clusterOfSize3Options := baseOptions
 		clusterOfSize3Options = append(clusterOfSize3Options, e2e.WithIsPeerTLS(true))
 		clusterOfSize3Options = append(clusterOfSize3Options, e2e.WithPeerProxy(true))
+		clusterOfSize3Options = append(clusterOfSize3Options, e2e.WithFaultyTransition(true))
 		if !v.LessThan(version.V3_6) {
 			clusterOfSize3Options = append(clusterOfSize3Options, e2e.WithSnapshotCatchUpEntries(100))
 		}


### PR DESCRIPTION
This is a network transition fault test in message level. It covers various network faults that raft shall tolerate, including blocked transition, message lost, message duplication, message delay, and message reordering. Some of these faults cannot be easily applied via existing test framework.